### PR TITLE
Fix peripheral.services not cleared when disconnect

### DIFF
--- a/lib/peripheral.js
+++ b/lib/peripheral.js
@@ -50,6 +50,7 @@ Peripheral.prototype.connect = function(callback) {
 Peripheral.prototype.disconnect = function(callback) {
   if (callback) {
     this.once('disconnect', function() {
+      this.services = null;
       callback(null);
     });
   }


### PR DESCRIPTION
https://github.com/comozilla/onigo-server/issues/51

peripheral.disconnect()した後もperipheral.servicesが残ってしまっているので、
disconnect時に初期化するように修正。